### PR TITLE
Redux architecture improvements.

### DIFF
--- a/actionstest.js
+++ b/actionstest.js
@@ -1,17 +1,28 @@
 var addWorkspaceSuccess = require('./redux/actions/workspace.js').addWorkspaceSuccess;
 var addWorkspace = require('./redux/actions/workspace.js').addWorkspace;
+var removeWorkspace = require('./redux/actions/workspace.js').removeWorkspace;
+
+var getWorkspaces = require('./redux/actions/workspace.js').getWorkspaces;
 var reducer = require('./redux/reducers/workspace.js');
 var store = require('./redux/store.js');
 var setCurrentPlace = require('./redux/actions/workspace.js').setCurrentPlace;
 
 let testContent = {
-    "name": "A Place",
-    "desc": "A desc"
-};
-
-let testPlace = {
-    "place": "Elias Middle of Nowhere"
+    "placeId":"ChIJ9-25gKYsDogRWBT2lu-OSi0",
+    "description": "short description",
+    "hasWifi": false,
+    "hasCaffeine": false,
+    "hasFood": false,
+    "hasOutlets": true,
+    "hasTableSpace": true,
+    "hasOutdoorSpace": false,
+    "isQuiet": false,
+    "isAccessible": false,
+    "quirks": "quirky",
+    "perks": "perky",
+    "directions": "directy"
 }
 
+// store.dispatch(getWorkspaces());
 // store.dispatch(addWorkspace(testContent));
-store.dispatch(setCurrentPlace(testPlace));
+store.dispatch(removeWorkspace('-KNGca9relU4AIY_I8Nl', 1))

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -1,24 +1,24 @@
 var firebaseApp = require('../../js/Firebase.jsx');
 require('isomorphic-fetch');
 
-const getMapPlace = (placeId) => {
-    return (dispatch) => {
-        let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
-            query = {
-            placed:  placeId,
-            key: 'AIzaSyDEW1grx0AbwSozmAu0fi7HczQn6D0UFlQ'
-        },
-            params = Object.keys(query)
-                .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
-                .join("&")
-                .replace(/%20/g, "+");
-        fetch(gMapsBaseUrl + '?' + params)
-            .then(res => res.json())
-        .then(place => {
-            return dispatch(getMapPlaceSuccess(place))
-        });
-    }
-}
+// const getMapPlace = (placeId) => {
+//     return (dispatch) => {
+//         let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
+//             query = {
+//             placed:  placeId,
+//             key: 'AIzaSyDEW1grx0AbwSozmAu0fi7HczQn6D0UFlQ'
+//         },
+//             params = Object.keys(query)
+//                 .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
+//                 .join("&")
+//                 .replace(/%20/g, "+");
+//         fetch(gMapsBaseUrl + '?' + params)
+//             .then(res => res.json())
+//         .then(place => {
+//             return dispatch(getMapPlaceSuccess(place))
+//         });
+//     }
+// }
 
 const getMapPlaceSuccess = (place) => {
     return {
@@ -70,6 +70,7 @@ const addWorkspace = (workspace) => {
 }
 
 const removeWorkspace = (workspaceId, workspaceIndex) => {
+    // assumes index of array of current workspaces can be captured at dispatch time.
     return function(dispatch) {
         let workspaceRef = firebaseApp.ref('/workspaces/').child(workspaceId);
         workspaceRef.remove().then(() => {

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -90,8 +90,10 @@ const removeWorkspaceSuccess = (index) => {
     }
 };
 
-exports.getMapPlace = getMapPlace;
-exports.getMapPlaceSuccess = getMapPlaceSuccess;
+// exports.getMapPlace = getMapPlace;
+// exports.getMapPlaceSuccess = getMapPlaceSuccess;
+
+exports.setCurrentPlace = setCurrentPlace;
 
 exports.getWorkspaces = getWorkspaces;
 exports.getWorkspacesSuccess = getWorkspacesSuccess;
@@ -101,5 +103,3 @@ exports.addWorkspaceSuccess = addWorkspaceSuccess;
 
 exports.removeWorkspace = removeWorkspace;
 exports.removeWorkspaceSuccess = removeWorkspaceSuccess;
-
-exports.setCurrentPlace = setCurrentPlace;

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -1,24 +1,24 @@
 var firebaseApp = require('../../js/Firebase.jsx');
 require('isomorphic-fetch');
 
-// const getMapPlace = (placeId) => {
-//     return (dispatch) => {
-//         let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
-//             query = {
-//             placed:  placeId,
-//             key: 'AIzaSyDEW1grx0AbwSozmAu0fi7HczQn6D0UFlQ'
-//         },
-//             params = Object.keys(query)
-//                 .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
-//                 .join("&")
-//                 .replace(/%20/g, "+");
-//         fetch(gMapsBaseUrl + '?' + params)
-//             .then(res => res.json())
-//         .then(place => {
-//             return dispatch(getMapPlaceSuccess(place))
-//         });
-//     }
-// }
+const getMapPlace = (placeId) => {
+    return (dispatch) => {
+        let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
+            query = {
+            placed:  placeId,
+            key: 'AIzaSyDEW1grx0AbwSozmAu0fi7HczQn6D0UFlQ'
+        },
+            params = Object.keys(query)
+                .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
+                .join("&")
+                .replace(/%20/g, "+");
+        fetch(gMapsBaseUrl + '?' + params)
+            .then(res => res.json())
+        .then(place => {
+            return dispatch(getMapPlaceSuccess(place))
+        });
+    }
+}
 
 const getMapPlaceSuccess = (place) => {
     return {
@@ -90,8 +90,8 @@ const removeWorkspaceSuccess = (index) => {
     }
 };
 
-// exports.getMapPlace = getMapPlace;
-// exports.getMapPlaceSuccess = getMapPlaceSuccess;
+exports.getMapPlace = getMapPlace;
+exports.getMapPlaceSuccess = getMapPlaceSuccess;
 
 exports.setCurrentPlace = setCurrentPlace;
 

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -27,18 +27,11 @@ const getMapPlaceSuccess = (place) => {
     }
 }
 
-const addWorkspaceSuccess = (workspace) => {
-	return {
-		type: 'ADD_WORKSPACE_SUCCESS',
-		workspace
-	};
-};
-
 const setCurrentPlace = (place) => {
-	return {
-		type: 'SET_CURRENT_PLACE',
-		place
-	}
+    return {
+        type: 'SET_CURRENT_PLACE',
+        place
+    }
 }
 
 const getWorkspaces = (filterParams) => {
@@ -61,13 +54,23 @@ const getWorkspacesSuccess = (workspaces) => {
 }
 
 const addWorkspace = (workspace) => {
-	return function(dispatch) {
-		let workspacesRef = firebaseApp.ref('/workspaces/');
-		dispatch(addWorkspaceSuccess(workspace));
-		workspacesRef.push(workspace);
+    return function(dispatch) {
+        let workspacesRef = firebaseApp.ref('/workspaces/');
+        dispatch(addWorkspaceSuccess(workspace));
+        workspacesRef.push(workspace);
 
-	}
-}
+    }
+};
+
+const addWorkspaceSuccess = (workspace) => {
+    return {
+        type: 'ADD_WORKSPACE_SUCCESS',
+        workspace
+    };
+};
+
+
+
 
 const removeWorkspace = (workspaceId, workspaceIndex) => {
     // assumes index of array of current workspaces can be captured at dispatch time.

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -1,33 +1,29 @@
 var update = require('react-addons-update');
 
 const initialState = {
-	currentWorkspaces: [0,1],
-    googlePlaces: [],
-    currentPlace: null,
+	placeIdCache: [],
+    placeId: null,
 	workspaceSaved: false
 };
 
 const workspaceReducer = (state, action) => {
-    console.log('here');
 	state = state || initialState;
-    if (action.type ==='GET_WORKSPACES_SUCCESS') {
-        let newState = update(state, {
-            currentWorkspaces: {$push: [action.workspaces]}
-        });
-    }
+    // if (action.type ==='GET_WORKSPACES_SUCCESS') {
+    //     let newState = update(state, {
+    //         placeIdCache: {$push: [action.workspaces]}
+    //     });
+    // }
     if (action.type === 'ADD_WORKSPACE_SUCCESS') {
         let newState = update(state, {
-            currentWorkspaces: { $push: [action.workspace]},
+            placeIdCache: { $push: [action.workspace]},
             workspaceSaved: { $set:true }
         });
         state = newState;
 	}
     if (action.type === 'REMOVE_WORKSPACE_SUCCESS') {
-        console.log('THE_ACTION=======',action)
         let newState = update(state, {
-            currentWorkspaces: {$splice: [[action.index, 1]]}
+            placeIdCache: {$splice: [[action.index, 1]]}
         });
-        console.log(newState);
     }
 	if (action.type === 'SET_CURRENT_PLACE') {
 		let newState = update(state, {

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -1,7 +1,7 @@
 var update = require('react-addons-update');
 
 const initialState = {
-	placeIdCache: [],
+	workspaceCache [],
     placeId: null,
 	workspaceSaved: false
 };
@@ -10,19 +10,18 @@ const workspaceReducer = (state, action) => {
 	state = state || initialState;
     if (action.type ==='GET_WORKSPACES_SUCCESS') {
         let newState = update(state, {
-            placeIdCache: {$push: [action.workspaces]}
+            workspaceCache {$push: [action.workspaces]}
         });
     }
     if (action.type === 'ADD_WORKSPACE_SUCCESS') {
         let newState = update(state, {
-            placeIdCache: { $push: [action.workspace]},
             workspaceSaved: { $set:true }
         });
         state = newState;
 	}
     if (action.type === 'REMOVE_WORKSPACE_SUCCESS') {
         let newState = update(state, {
-            placeIdCache: {$splice: [[action.index, 1]]}
+            workspaceCache {$splice: [[action.index, 1]]}
         });
     }
 	if (action.type === 'SET_CURRENT_PLACE') {

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -31,10 +31,10 @@ const workspaceReducer = (state, action) => {
 		state = newState;
         console.log(newState);
     }
-    // if (action.type === 'GET_MAP_PLACE_SCCESS') {
-    //     let newState = update(state, {
-    //         googlePlaces: {$push: action.place}
-    //     })
+    if (action.type === 'GET_MAP_PLACE_SCCESS') {
+        let newState = update(state, {
+            googlePlaces: {$push: action.place}
+        })
     }
 
     return state;

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -8,11 +8,11 @@ const initialState = {
 
 const workspaceReducer = (state, action) => {
 	state = state || initialState;
-    // if (action.type ==='GET_WORKSPACES_SUCCESS') {
-    //     let newState = update(state, {
-    //         placeIdCache: {$push: [action.workspaces]}
-    //     });
-    // }
+    if (action.type ==='GET_WORKSPACES_SUCCESS') {
+        let newState = update(state, {
+            placeIdCache: {$push: [action.workspaces]}
+        });
+    }
     if (action.type === 'ADD_WORKSPACE_SUCCESS') {
         let newState = update(state, {
             placeIdCache: { $push: [action.workspace]},
@@ -32,10 +32,10 @@ const workspaceReducer = (state, action) => {
 		state = newState;
         console.log(newState);
     }
-    if (action.type === 'GET_MAP_PLACE_SCCESS') {
-        let newState = update(state, {
-            googlePlaces: {$push: action.place}
-        })
+    // if (action.type === 'GET_MAP_PLACE_SCCESS') {
+    //     let newState = update(state, {
+    //         googlePlaces: {$push: action.place}
+    //     })
     }
 
     return state;


### PR DESCRIPTION
The `initialState` of the app is now simpler with better semantics for its prop names. Code has been moved around and cleaned-up slightly.

With the changes from #29, we should be able to do `getWorkspaces()` to put workspaces in the state's `workspaceCache`, and from there make an array of the placeIds, and with that array, use Google's API to put pins on the map. Note that Google's [JS library](https://developers.google.com/maps/documentation/javascript/places) for Places will probably make this a lot easier than doing it with the existing RESTFUL API call.
