### PR TITLE
Enable GPU rasterization

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1">
   <title>CozyFi</title>
   <!-- <script src="https://maps.googleapis.com/maps/api/js"></script> -->
 </head>


### PR DESCRIPTION
`<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1">` triggers GPU rasterization where available, improving paint time.
