### PR TITLE
Prevent GMaps data from reaching Firebase DB

### DIFF
--- a/actionstest.js
+++ b/actionstest.js
@@ -24,5 +24,19 @@ let testContent = {
 }
 
 store.dispatch(fetchWorkspaceData());
-// store.dispatch(addWorkspace(testContent));
+// store.dispatch(addWorkspace({
+//     "placeId":"ChIJ7zbMpZpZwoARjbdOvuQKcn8",
+//     "description": "short description",
+//     "hasWifi": true,
+//     "hasCaffeine": true,
+//     "hasFood": true,
+//     "hasOutlets": true,
+//     "hasTableSpace": true,
+//     "hasOutdoorSpace": true,
+//     "isQuiet": true,
+//     "isAccessible": true,
+//     "quirks": "quirky",
+//     "perks": "perky",
+//     "directions": "directy"
+// }));
 // store.dispatch(removeWorkspace('-KNGca9relU4AIY_I8Nl', 1))

--- a/actionstest.js
+++ b/actionstest.js
@@ -2,7 +2,7 @@ var addWorkspaceSuccess = require('./redux/actions/workspace.js').addWorkspaceSu
 var addWorkspace = require('./redux/actions/workspace.js').addWorkspace;
 var removeWorkspace = require('./redux/actions/workspace.js').removeWorkspace;
 
-var getWorkspaces = require('./redux/actions/workspace.js').getWorkspaces;
+var fetchWorkspaceData = require('./redux/actions/workspace.js').fetchWorkspaceData;
 var reducer = require('./redux/reducers/workspace.js');
 var store = require('./redux/store.js');
 var setCurrentPlace = require('./redux/actions/workspace.js').setCurrentPlace;
@@ -23,6 +23,6 @@ let testContent = {
     "directions": "directy"
 }
 
-store.dispatch(getWorkspaces());
+store.dispatch(fetchWorkspaceData());
 // store.dispatch(addWorkspace(testContent));
 // store.dispatch(removeWorkspace('-KNGca9relU4AIY_I8Nl', 1))

--- a/js/Cardz.jsx
+++ b/js/Cardz.jsx
@@ -93,7 +93,7 @@ class Cardz extends React.Component {
   };
 
   componentWillMount() {
-      this.props.dispatch(actions.getWorkspaces()); // puts the data in the store
+      this.props.dispatch(actions.fetchWorkspaceData()); // puts the data in the store
 
 
 

--- a/js/Form.jsx
+++ b/js/Form.jsx
@@ -102,7 +102,8 @@ const Form = React.createClass({
   },
 
   submitForm(formData) {
-      let completeWorkspace = Object.assign({}, formData, {placeData: this.props.state.placeData.name});
+      console.log(this.props.state);
+      let completeWorkspace = Object.assign({}, formData, {placeId: this.props.state.currentPlace});
       console.log(completeWorkspace);
       this.props.dispatch(actions.addWorkspace(completeWorkspace));
   },

--- a/js/FormMap.jsx
+++ b/js/FormMap.jsx
@@ -57,7 +57,7 @@ export default class FormMap extends React.Component {
   handlePlacesChanged() {
       console.log('=======')
     const places = this.refs.searchBox.getPlaces();
-    const place = places[0];
+    const placeId = places[0].place_id;
     const markers = [];
 
     // Add a marker for each place returned from search bar
@@ -75,7 +75,7 @@ export default class FormMap extends React.Component {
       markers
     });
 
-    this.props.dispatch(actions.saveMapPlaceSuccess(place));
+    this.props.dispatch(actions.setCurrentPlace(placeId));
 
   }
 

--- a/js/FormMap.jsx
+++ b/js/FormMap.jsx
@@ -55,7 +55,7 @@ export default class FormMap extends React.Component {
   }
 
   handlePlacesChanged() {
-      console.log('=======')
+
     const places = this.refs.searchBox.getPlaces();
     const placeId = places[0].place_id;
     const markers = [];

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -21,13 +21,6 @@ const fetchWorkspaceData = (filterParams) => {
     }
 }
 
-// const fetchWorkspaceDataSuccess = (workspaces) => {
-//     return {
-//         type: 'FETCH_WORKSPACE_DATA_SUCCESS',
-//         workspaces
-//     }
-// }
-
 const fetchMapData = (workspaces) => {
     return (dispatch, getState) => {
         let service = getState().placesService;
@@ -35,12 +28,13 @@ const fetchMapData = (workspaces) => {
 
         for (var i = 0; i <= workspaces.length; i +=1) {
             var request = {
-                placeId: workspaces[i].placeId
+                placeId: workspaces[i].placeId,
+                workspace: workspaces[i]
             }
             service.getDetails(request, (place, status) => {
                 if (status == google.maps.places.PlacesServiceStatus.OK) {
                     let workspaceWithGData =
-                        Object.assign({}, workspaces[i], {googleData: place});
+                        Object.assign({}, request.workspace, {googleData: place});
                     mergedWorkspaces.push(workspaceWithGData);
                 }
                 dispatch(updateWorkspaceCache(mergedWorkspaces));

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -3,6 +3,7 @@ require('isomorphic-fetch');
 
 const mapWorkspaces = (workspaces) => {
     return (dispatch) => {
+        // nest this in a loop!
             let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
                 query = {
                 placeid:  'ChIJ7zbMpZpZwoARjbdOvuQKcn8',
@@ -13,9 +14,7 @@ const mapWorkspaces = (workspaces) => {
                     .join("&")
                     .replace(/%20/g, "+");
             fetch(gMapsBaseUrl + '?' + params)
-                .then(res => {
-                    return res.json()
-                })
+                .then(res => res.json())
                 .then(res => console.log(res.result.formatted_address));
     }
 }
@@ -41,7 +40,7 @@ const setCurrentPlace = (placeId) => {
     }
 }
 
-const getWorkspaces = (filterParams) => {
+const fetchWorkspaceData = (filterParams) => {
     return (dispatch) => {
         let placesArray = []
         let workspacesRef = firebaseApp.ref('/workspaces/');
@@ -53,9 +52,9 @@ const getWorkspaces = (filterParams) => {
     }
 }
 
-const getWorkspacesSuccess = (workspaces) => {
+const fetchWorkspaceDataSuccess = (workspaces) => {
     return {
-        type: 'GET_WORKSPACES_SUCCESS',
+        type: FETCH_WORKSPACE_DATA_SUCCESS,
         workspaces
     }
 }
@@ -102,8 +101,8 @@ exports.mapWorkspaces = mapWorkspaces;
 
 exports.setCurrentPlace = setCurrentPlace;
 
-exports.getWorkspaces = getWorkspaces;
-exports.getWorkspacesSuccess = getWorkspacesSuccess;
+exports.fetchWorkspaceData = fetchWorkspaceData;
+exports.fetchWorkspaceDataSuccess = fetchWorkspaceDataSuccess;
 
 exports.addWorkspace = addWorkspace;
 exports.addWorkspaceSuccess = addWorkspaceSuccess;

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -4,9 +4,24 @@ require('isomorphic-fetch');
 const mapWorkspaces = (workspaces) => {
     return (dispatch) => {
         // nest this in a loop!
+        let workspace = {
+            "placeId":"ChIJ9-25gKYsDogRWBT2lu-OSi0",
+            "description": "short description",
+            "hasWifi": false,
+            "hasCaffeine": false,
+            "hasFood": false,
+            "hasOutlets": true,
+            "hasTableSpace": true,
+            "hasOutdoorSpace": false,
+            "isQuiet": false,
+            "isAccessible": false,
+            "quirks": "quirky",
+            "perks": "perky",
+            "directions": "directy"
+        }
             let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
                 query = {
-                placeid:  'ChIJ7zbMpZpZwoARjbdOvuQKcn8',
+                placeid:  workspace.placeId,
                 key: 'AIzaSyDEW1grx0AbwSozmAu0fi7HczQn6D0UFlQ'
             },
                 params = Object.keys(query)
@@ -15,7 +30,12 @@ const mapWorkspaces = (workspaces) => {
                     .replace(/%20/g, "+");
             fetch(gMapsBaseUrl + '?' + params)
                 .then(res => res.json())
-                .then(res => console.log(res.result.formatted_address));
+                .then(res => {
+                    let googleData = res.result;
+                    let workspaceWithGData =
+                      Object.assign({}, workspace, {googleData: googleData});
+                      return console.log(workspaceWithGData);
+                });
     }
 }
 
@@ -54,7 +74,7 @@ const fetchWorkspaceData = (filterParams) => {
 
 const fetchWorkspaceDataSuccess = (workspaces) => {
     return {
-        type: FETCH_WORKSPACE_DATA_SUCCESS,
+        type: 'FETCH_WORKSPACE_DATA_SUCCESS',
         workspaces
     }
 }

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -1,7 +1,7 @@
 var firebaseApp = require('../../js/Firebase.jsx');
 require('isomorphic-fetch');
 
-const mapWorkspaces = (workspaces) => {
+const fetchMapData = (workspaces) => {
     return (dispatch) => {
         // nest this in a loop; perform this work on array
         let workspace = {
@@ -39,9 +39,9 @@ const mapWorkspaces = (workspaces) => {
     }
 }
 
-const mapWorkspaceDataSuccess = (place) => {
+const fetchMapDataSuccess = (workspaces) => {
     return {
-        type: 'GET_MAP_PLACE_SUCCESS',
+        type: 'FETCH_MAP_DATA_SUCCESS',
         place
     }
 }
@@ -67,7 +67,7 @@ const fetchWorkspaceData = (filterParams) => {
         workspacesRef.once('value').then(snapshot => {
         const data = snapshot.val();
         const workspaces = Object.keys(data).map(key => data[key]);
-            dispatch(mapWorkspaces(workspaces));
+            dispatch(fetchMapData(workspaces));
         });
     }
 }
@@ -116,8 +116,8 @@ const removeWorkspaceSuccess = (index) => {
     }
 };
 
-exports.mapWorkspaces = mapWorkspaces;
-exports.mapWorkspacessSuccess = mapWorkspacesSuccess;
+exports.fetchMapData = fetchMapData;
+exports.fetchMapDatasSuccess = fetchMapDataSuccess;
 
 exports.setCurrentPlace = setCurrentPlace;
 

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -114,6 +114,8 @@ exports.fetchWorkspaceDataSuccess = fetchWorkspaceDataSuccess;
 exports.fetchMapData = fetchMapData;
 exports.fetchMapDatasSuccess = fetchMapDataSuccess;
 
+exports.updateWorkspaceCache = updateWorkspaceCache;
+
 exports.addWorkspace = addWorkspace;
 exports.addWorkspaceSuccess = addWorkspaceSuccess;
 

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -3,7 +3,7 @@ require('isomorphic-fetch');
 
 const mapWorkspaces = (workspaces) => {
     return (dispatch) => {
-        // nest this in a loop!
+        // nest this in a loop; perform this work on array
         let workspace = {
             "placeId":"ChIJ9-25gKYsDogRWBT2lu-OSi0",
             "description": "short description",
@@ -39,7 +39,7 @@ const mapWorkspaces = (workspaces) => {
     }
 }
 
-const getMapPlaceSuccess = (place) => {
+const mapWorkspaceDataSuccess = (place) => {
     return {
         type: 'GET_MAP_PLACE_SUCCESS',
         place
@@ -117,7 +117,7 @@ const removeWorkspaceSuccess = (index) => {
 };
 
 exports.mapWorkspaces = mapWorkspaces;
-// exports.mapWorkspacessSuccess = mapWorkspacesSuccess;
+exports.mapWorkspacessSuccess = mapWorkspacesSuccess;
 
 exports.setCurrentPlace = setCurrentPlace;
 

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -1,64 +1,13 @@
 var firebaseApp = require('../../js/Firebase.jsx');
 require('isomorphic-fetch');
 
-const fetchMapData = (workspaces) => {
-    return (dispatch) => {
-        // nest this in a loop; perform this work on array
-        let workspace = {
-            "placeId":"ChIJ9-25gKYsDogRWBT2lu-OSi0",
-            "description": "short description",
-            "hasWifi": false,
-            "hasCaffeine": false,
-            "hasFood": false,
-            "hasOutlets": true,
-            "hasTableSpace": true,
-            "hasOutdoorSpace": false,
-            "isQuiet": false,
-            "isAccessible": false,
-            "quirks": "quirky",
-            "perks": "perky",
-            "directions": "directy"
-        }
-            let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
-                query = {
-                placeid:  workspace.placeId,
-                key: 'AIzaSyDEW1grx0AbwSozmAu0fi7HczQn6D0UFlQ'
-            },
-                params = Object.keys(query)
-                    .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
-                    .join("&")
-                    .replace(/%20/g, "+");
-            fetch(gMapsBaseUrl + '?' + params)
-                .then(res => res.json())
-                .then(res => {
-                    let googleData = res.result;
-                    let workspaceWithGData =
-                      Object.assign({}, workspace, {googleData: googleData});
-                      return console.log(workspaceWithGData);
-                });
-    }
-}
-
-const fetchMapDataSuccess = (workspaces) => {
-    return {
-        type: 'FETCH_MAP_DATA_SUCCESS',
-        place
-    }
-}
-
-const saveMapPlaceSuccess = (place) => {
-    return {
-        type: 'SAVE_MAP_PLACE_SUCCESS',
-        place
-    }
-}
-
 const setCurrentPlace = (placeId) => {
     return {
         type: 'SET_CURRENT_PLACE',
         placeId
     }
 }
+
 
 const fetchWorkspaceData = (filterParams) => {
     return (dispatch) => {
@@ -79,6 +28,47 @@ const fetchWorkspaceDataSuccess = (workspaces) => {
     }
 }
 
+const fetchMapData = (workspaces) => {
+    return (dispatch) => {
+        // nest this in a loop; perform this work on array
+        let workspace = {
+            "placeId":"ChIJ9-25gKYsDogRWBT2lu-OSi0",
+            "description": "short description",
+            "hasWifi": false,
+            "hasCaffeine": false,
+            "hasFood": false,
+            "hasOutlets": true,
+            "hasTableSpace": true,
+            "hasOutdoorSpace": false,
+            "isQuiet": false,
+            "isAccessible": false,
+            "quirks": "quirky",
+            "perks": "perky",
+            "directions": "directy"
+        }
+        let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
+        query = {
+            placeid:  workspace.placeId,
+            key: 'AIzaSyDEW1grx0AbwSozmAu0fi7HczQn6D0UFlQ'
+        },
+        params = Object.keys(query)
+        .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
+        .join("&")
+        .replace(/%20/g, "+");
+        fetch(gMapsBaseUrl + '?' + params)
+        .then(res => res.json())
+        .then(res => {
+            let workspacesWithGData =
+            Object.assign({}, workspace, {googleData: res.result});
+            return dispatch(fetchMapDataSuccess(workspacesWithGData));
+        });
+    }
+}
+
+const fetchMapDataSuccess = (workspaces) => {
+    return dispatch(updateWorkspaceCache)
+}
+
 const addWorkspace = (workspace) => {
     return function(dispatch) {
         let workspacesRef = firebaseApp.ref('/workspaces/');
@@ -96,8 +86,6 @@ const addWorkspaceSuccess = (workspace) => {
 };
 
 
-
-
 const removeWorkspace = (workspaceId, workspaceIndex) => {
     // assumes index of array of current workspaces can be captured at dispatch time.
     return function(dispatch) {
@@ -105,7 +93,6 @@ const removeWorkspace = (workspaceId, workspaceIndex) => {
         workspaceRef.remove().then(() => {
             dispatch(removeWorkspaceSuccess(workspaceIndex));
         })
-
     }
 };
 
@@ -116,13 +103,13 @@ const removeWorkspaceSuccess = (index) => {
     }
 };
 
-exports.fetchMapData = fetchMapData;
-exports.fetchMapDatasSuccess = fetchMapDataSuccess;
-
 exports.setCurrentPlace = setCurrentPlace;
 
 exports.fetchWorkspaceData = fetchWorkspaceData;
 exports.fetchWorkspaceDataSuccess = fetchWorkspaceDataSuccess;
+
+exports.fetchMapData = fetchMapData;
+exports.fetchMapDatasSuccess = fetchMapDataSuccess;
 
 exports.addWorkspace = addWorkspace;
 exports.addWorkspaceSuccess = addWorkspaceSuccess;

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -31,39 +31,8 @@ const fetchWorkspaceData = (filterParams) => {
 const fetchMapData = (workspaces) => {
     return (dispatch, getState) => {
         let service = getState().placesService;
-
         let mergedWorkspaces = [];
-        let workspaces = [{
-            "placeId":"ChIJ7zbMpZpZwoARjbdOvuQKcn8",
-            "googleData": null,
-            "description": "short description",
-            "hasWifi": true,
-            "hasCaffeine": true,
-            "hasFood": true,
-            "hasOutlets": true,
-            "hasTableSpace": true,
-            "hasOutdoorSpace": true,
-            "isQuiet": true,
-            "isAccessible": true,
-            "quirks": "quirky",
-            "perks": "perky",
-            "directions": "directy"
-        },{
-            "placeId":"ChIJp6fWcohcwoARrIWK0sUe-VE",
-            "googleData": null,
-            "description": "short description",
-            "hasWifi": false,
-            "hasCaffeine": false,
-            "hasFood": false,
-            "hasOutlets": true,
-            "hasTableSpace": true,
-            "hasOutdoorSpace": false,
-            "isQuiet": false,
-            "isAccessible": false,
-            "quirks": "quirky",
-            "perks": "perky",
-            "directions": "directy"
-        }]
+
         for (var i = 0; i <= workspaces.length; i +=1) {
             var request = {
                 placeId: workspaces[i].placeId
@@ -71,10 +40,9 @@ const fetchMapData = (workspaces) => {
             service.getDetails(request, (place, status) => {
                 if (status == google.maps.places.PlacesServiceStatus.OK) {
                     let workspaceWithGData =
-                    Object.assign({}, workspaces[i], {googleData: place});
+                        Object.assign({}, workspaces[i], {googleData: place});
                     mergedWorkspaces.push(workspaceWithGData);
                 }
-
                 dispatch(updateWorkspaceCache(mergedWorkspaces));
             });
         }
@@ -123,13 +91,8 @@ const removeWorkspaceSuccess = (index) => {
 };
 
 exports.setCurrentPlace = setCurrentPlace;
-
 exports.fetchWorkspaceData = fetchWorkspaceData;
-// exports.fetchWorkspaceDataSuccess = fetchWorkspaceDataSuccess;
-
 exports.fetchMapData = fetchMapData;
-// exports.fetchMapDatasSuccess = fetchMapDataSuccess;
-
 exports.updateWorkspaceCache = updateWorkspaceCache;
 
 exports.addWorkspace = addWorkspace;

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -29,8 +29,9 @@ const fetchWorkspaceData = (filterParams) => {
 // }
 
 const fetchMapData = (workspaces) => {
-    return (dispatch) => {
-        // nest this in a loop; perform this work on array
+    return (dispatch, getState) => {
+        let service = getState().placesService;
+
         let mergedWorkspaces = [];
         let workspaces = [{
             "placeId":"ChIJ7zbMpZpZwoARjbdOvuQKcn8",
@@ -64,22 +65,17 @@ const fetchMapData = (workspaces) => {
             "directions": "directy"
         }]
         for (var i = 0; i <= workspaces.length; i +=1) {
-            let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
-            query = {
-                placeid:  workspaces[i].placeId,
-                key: 'AIzaSyAxTnTQ3fTqVc3bE5MhFw7qXYq0o1NUJpo'
-            },
-            params = Object.keys(query)
-            .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
-            .join("&")
-            .replace(/%20/g, "+");
-            fetch(gMapsBaseUrl + '?' + params, {headers: new Headers(), mode: 'cors'})
-            .then(res => res.json())
-            .then(res => {
-                let workspaceWithGData =
-                Object.assign({}, workspaces[i], {googleData: res.result});
-                 mergedWorkspaces.push(workspaceWithGData);
-                 return console.log(mergedWorkspaces)
+            var request = {
+                placeId: workspaces[i].placeId
+            }
+            service.getDetails(request, (place, status) => {
+                if (status == google.maps.places.PlacesServiceStatus.OK) {
+                    let workspaceWithGData =
+                    Object.assign({}, workspaces[i], {googleData: place});
+                    mergedWorkspaces.push(workspaceWithGData);
+                }
+
+                dispatch(updateWorkspaceCache(mergedWorkspaces));
             });
         }
     }

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -31,8 +31,25 @@ const fetchWorkspaceData = (filterParams) => {
 const fetchMapData = (workspaces) => {
     return (dispatch) => {
         // nest this in a loop; perform this work on array
-        let workspace = {
-            "placeId":"ChIJ9-25gKYsDogRWBT2lu-OSi0",
+        let mergedWorkspaces = [];
+        let workspaces = [{
+            "placeId":"ChIJ7zbMpZpZwoARjbdOvuQKcn8",
+            "googleData": null,
+            "description": "short description",
+            "hasWifi": true,
+            "hasCaffeine": true,
+            "hasFood": true,
+            "hasOutlets": true,
+            "hasTableSpace": true,
+            "hasOutdoorSpace": true,
+            "isQuiet": true,
+            "isAccessible": true,
+            "quirks": "quirky",
+            "perks": "perky",
+            "directions": "directy"
+        },{
+            "placeId":"ChIJp6fWcohcwoARrIWK0sUe-VE",
+            "googleData": null,
             "description": "short description",
             "hasWifi": false,
             "hasCaffeine": false,
@@ -45,23 +62,26 @@ const fetchMapData = (workspaces) => {
             "quirks": "quirky",
             "perks": "perky",
             "directions": "directy"
+        }]
+        for (var i = 0; i <= workspaces.length; i +=1) {
+            let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
+            query = {
+                placeid:  workspaces[i].placeId,
+                key: 'AIzaSyAxTnTQ3fTqVc3bE5MhFw7qXYq0o1NUJpo'
+            },
+            params = Object.keys(query)
+            .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
+            .join("&")
+            .replace(/%20/g, "+");
+            fetch(gMapsBaseUrl + '?' + params, {headers: new Headers(), mode: 'cors'})
+            .then(res => res.json())
+            .then(res => {
+                let workspaceWithGData =
+                Object.assign({}, workspaces[i], {googleData: res.result});
+                 mergedWorkspaces.push(workspaceWithGData);
+                 return console.log(mergedWorkspaces)
+            });
         }
-        let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
-        query = {
-            placeid:  workspace.placeId,
-            key: 'AIzaSyDEW1grx0AbwSozmAu0fi7HczQn6D0UFlQ'
-        },
-        params = Object.keys(query)
-        .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
-        .join("&")
-        .replace(/%20/g, "+");
-        fetch(gMapsBaseUrl + '?' + params)
-        .then(res => res.json())
-        .then(res => {
-            let workspacesWithGData =
-            Object.assign({}, workspace, {googleData: res.result});
-            return dispatch(updateWorkspaceCache(workspacesWithGData));
-        });
     }
 }
 
@@ -109,10 +129,10 @@ const removeWorkspaceSuccess = (index) => {
 exports.setCurrentPlace = setCurrentPlace;
 
 exports.fetchWorkspaceData = fetchWorkspaceData;
-exports.fetchWorkspaceDataSuccess = fetchWorkspaceDataSuccess;
+// exports.fetchWorkspaceDataSuccess = fetchWorkspaceDataSuccess;
 
 exports.fetchMapData = fetchMapData;
-exports.fetchMapDatasSuccess = fetchMapDataSuccess;
+// exports.fetchMapDatasSuccess = fetchMapDataSuccess;
 
 exports.updateWorkspaceCache = updateWorkspaceCache;
 

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -1,6 +1,32 @@
 var firebaseApp = require('../../js/Firebase.jsx');
 require('isomorphic-fetch');
 
+const mapWorkspaces = (workspaces) => {
+    return (dispatch) => {
+            let gMapsBaseUrl = 'https://maps.googleapis.com/maps/api/place/details/json',
+                query = {
+                placeid:  'ChIJ7zbMpZpZwoARjbdOvuQKcn8',
+                key: 'AIzaSyDEW1grx0AbwSozmAu0fi7HczQn6D0UFlQ'
+            },
+                params = Object.keys(query)
+                    .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
+                    .join("&")
+                    .replace(/%20/g, "+");
+            fetch(gMapsBaseUrl + '?' + params)
+                .then(res => {
+                    return res.json()
+                })
+                .then(res => console.log(res.result.formatted_address));
+    }
+}
+
+const getMapPlaceSuccess = (place) => {
+    return {
+        type: 'GET_MAP_PLACE_SUCCESS',
+        place
+    }
+}
+
 const saveMapPlaceSuccess = (place) => {
     return {
         type: 'SAVE_MAP_PLACE_SUCCESS',
@@ -8,21 +34,21 @@ const saveMapPlaceSuccess = (place) => {
     }
 }
 
-const setCurrentPlace = (place) => {
+const setCurrentPlace = (placeId) => {
     return {
         type: 'SET_CURRENT_PLACE',
-        place
+        placeId
     }
 }
 
 const getWorkspaces = (filterParams) => {
     return (dispatch) => {
+        let placesArray = []
         let workspacesRef = firebaseApp.ref('/workspaces/');
         workspacesRef.once('value').then(snapshot => {
-            const data = snapshot.val();
-            const workspaces = Object.keys(data).map(key => data[key]);
-            console.log(workspaces);
-            dispatch(getWorkspacesSuccess(workspaces));
+        const data = snapshot.val();
+        const workspaces = Object.keys(data).map(key => data[key]);
+            dispatch(mapWorkspaces(workspaces));
         });
     }
 }
@@ -71,8 +97,8 @@ const removeWorkspaceSuccess = (index) => {
     }
 };
 
-// exports.saveMapPlace = saveMapPlace;
-exports.saveMapPlaceSuccess = saveMapPlaceSuccess;
+exports.mapWorkspaces = mapWorkspaces;
+// exports.mapWorkspacessSuccess = mapWorkspacesSuccess;
 
 exports.setCurrentPlace = setCurrentPlace;
 

--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -21,12 +21,12 @@ const fetchWorkspaceData = (filterParams) => {
     }
 }
 
-const fetchWorkspaceDataSuccess = (workspaces) => {
-    return {
-        type: 'FETCH_WORKSPACE_DATA_SUCCESS',
-        workspaces
-    }
-}
+// const fetchWorkspaceDataSuccess = (workspaces) => {
+//     return {
+//         type: 'FETCH_WORKSPACE_DATA_SUCCESS',
+//         workspaces
+//     }
+// }
 
 const fetchMapData = (workspaces) => {
     return (dispatch) => {
@@ -60,13 +60,16 @@ const fetchMapData = (workspaces) => {
         .then(res => {
             let workspacesWithGData =
             Object.assign({}, workspace, {googleData: res.result});
-            return dispatch(fetchMapDataSuccess(workspacesWithGData));
+            return dispatch(updateWorkspaceCache(workspacesWithGData));
         });
     }
 }
 
-const fetchMapDataSuccess = (workspaces) => {
-    return dispatch(updateWorkspaceCache)
+const updateWorkspaceCache = (workspaces) => {
+    return {
+        type: 'UPDATE_WORKSPACE_CACHE',
+        workspaces
+    }
 }
 
 const addWorkspace = (workspace) => {

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -9,7 +9,7 @@ const initialState = {
 
 const workspaceReducer = (state, action) => {
 	state = state || initialState;
-    if (action.type ===FETCH_WORKSPACE_DATA_SUCCESS) {
+    if (action.type ==='FETCH_WORKSPACE_DATA_SUCCESS') {
         let newState = update(state, {
             workspaceCache: {$push: action.workspaces}
         });

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -4,8 +4,9 @@ const initialState = {
 	workspaceCache: [],
     placeId: null,
     placeData: null,
-	workspaceSaved: false
-};
+	workspaceSaved: false,
+    placesService: new google.maps.places.PlacesService(document.createElement('div'))
+}
 
 const workspaceReducer = (state, action) => {
 	state = state || initialState;
@@ -13,6 +14,7 @@ const workspaceReducer = (state, action) => {
         let newState = update(state, {
             workspaceCache: {$push: action.workspaces}
         });
+        console.log('-+_+_+_+_+_+_+__+_');
         state = newState;
     }
     if (action.type === 'ADD_WORKSPACE_SUCCESS') {

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -28,7 +28,7 @@ const workspaceReducer = (state, action) => {
     }
 	if (action.type === 'SET_CURRENT_PLACE') {
 		let newState = update(state, {
-		currentPlace: {$set: action.place}
+		currentPlace: {$set: action.placeId}
     });
 		state = newState;
     }
@@ -38,7 +38,6 @@ const workspaceReducer = (state, action) => {
         });
         state = newState;
     }
-    console.log(state);
     return state;
 };
 

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -33,12 +33,6 @@ const workspaceReducer = (state, action) => {
     });
 		state = newState;
     }
-    if (action.type === 'SAVE_MAP_PLACE_SUCCESS') {
-        let newState = update(state, {
-            placeData: {$set: action.place}
-        });
-        state = newState;
-    }
     return state;
 };
 

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -3,7 +3,7 @@ var update = require('react-addons-update');
 const initialState = {
 	workspaceCache: [],
     placeId: null,
-    placeData: null,
+    googleData: null,
 	workspaceSaved: false,
     placesService: new google.maps.places.PlacesService(document.createElement('div'))
 }
@@ -14,7 +14,6 @@ const workspaceReducer = (state, action) => {
         let newState = update(state, {
             workspaceCache: {$push: action.workspaces}
         });
-        console.log('-+_+_+_+_+_+_+__+_');
         state = newState;
     }
     if (action.type === 'ADD_WORKSPACE_SUCCESS') {

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -9,7 +9,7 @@ const initialState = {
 
 const workspaceReducer = (state, action) => {
 	state = state || initialState;
-    if (action.type ==='FETCH_WORKSPACE_DATA_SUCCESS') {
+    if (action.type ==='UPDATE_WORKSPACE_CACHE') {
         let newState = update(state, {
             workspaceCache: {$push: action.workspaces}
         });

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -10,9 +10,6 @@ const initialState = {
 const workspaceReducer = (state, action) => {
 	state = state || initialState;
     if (action.type ==='GET_WORKSPACES_SUCCESS') {
-        console.log('=========')
-        console.log(action.workspaces);
-        console.log('=========')
         let newState = update(state, {
             workspaceCache: {$push: action.workspaces}
         });

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -9,7 +9,7 @@ const initialState = {
 
 const workspaceReducer = (state, action) => {
 	state = state || initialState;
-    if (action.type ==='GET_WORKSPACES_SUCCESS') {
+    if (action.type ===FETCH_WORKSPACE_DATA_SUCCESS) {
         let newState = update(state, {
             workspaceCache: {$push: action.workspaces}
         });


### PR DESCRIPTION
This is an massive overhaul of the way our application handles the Google Maps data. it makes Maps API calls at the right time to prevent relying on Firebase to store any Place data.

Now, when the landing page mounts:
- Cardz dispatches `fetchWorkspaceData()`
- a successful return from `fetchWorkspaceData()` dispatches `fetchMapData()`
- a successful return from `fetchMapData()` dispatches `updateWorkspaceCache`
- that cache is what becomes available to the `Cardz` for rendering.

GMaps data is now available in the `googleData` prop of each object in `workspaceCache`; React must change how it accesses this data (#39) .
