### PR TITLE
Hotfix: Ensure fetch & display of correct workspace data.

### DIFF
--- a/redux/actions/workspace.js
+++ b/redux/actions/workspace.js
@@ -25,20 +25,23 @@ const fetchMapData = (workspaces) => {
     return (dispatch, getState) => {
         let service = getState().placesService;
         let mergedWorkspaces = [];
+        let count = workspaces.length
 
-        for (var i = 0; i <= workspaces.length; i +=1) {
+        for (var i = 0; i < workspaces.length; i +=1) {
             var request = {
-                placeId: workspaces[i].placeId,
-                workspace: workspaces[i]
+                placeId: workspaces[i].placeId
             }
-            service.getDetails(request, (place, status) => {
+            service.getDetails(request, function(workspace, place, status) {
                 if (status == google.maps.places.PlacesServiceStatus.OK) {
-                    let workspaceWithGData =
-                        Object.assign({}, request.workspace, {googleData: place});
+                    var workspaceWithGData =
+                        Object.assign({}, workspace, {googleData: place});
                     mergedWorkspaces.push(workspaceWithGData);
+                    count --;
                 }
-                dispatch(updateWorkspaceCache(mergedWorkspaces));
-            });
+                if (count === 0){
+                    dispatch(updateWorkspaceCache(mergedWorkspaces));
+                }
+            }.bind(null, workspaces[i]));
         }
     }
 }

--- a/redux/reducers/workspace.js
+++ b/redux/reducers/workspace.js
@@ -12,7 +12,7 @@ const workspaceReducer = (state, action) => {
 	state = state || initialState;
     if (action.type ==='UPDATE_WORKSPACE_CACHE') {
         let newState = update(state, {
-            workspaceCache: {$push: action.workspaces}
+            workspaceCache: {$set: action.workspaces}
         });
         state = newState;
     }


### PR DESCRIPTION
Use of binding allows us to ensure the right local workspace is being used to fetch data from Google; waiting for a count to finish ensures that we only actually update the cache once each workspace's relevant Google data has been fetched.

Fixes #39.
